### PR TITLE
Insert spaces after newlines

### DIFF
--- a/mdbook-shared/src/summary.rs
+++ b/mdbook-shared/src/summary.rs
@@ -601,9 +601,7 @@ fn get_last_link<R>(links: &mut [SummaryItem<R>]) -> Result<(usize, &mut Link<R>
     links
         .iter_mut()
         .enumerate()
-        .filter_map(|(i, item)| item.maybe_link_mut().map(|l| (i, l)))
-        .rev()
-        .next()
+        .filter_map(|(i, item)| item.maybe_link_mut().map(|l| (i, l))).next_back()
         .ok_or_else(||
             anyhow::anyhow!("Unable to get last link because the list of SummaryItems doesn't contain any Links")
             )

--- a/syntect-html/src/lib.rs
+++ b/syntect-html/src/lib.rs
@@ -46,7 +46,7 @@ impl CodeBlock {
                 format!("No syntax found for extension {}", extension),
             )
         })?;
-        let html = syntect::html::highlighted_html_for_string(&code, &ss, &syntax, theme).map_err(
+        let html = syntect::html::highlighted_html_for_string(&code, &ss, syntax, theme).map_err(
             |err| {
                 syn::Error::new(
                     Span::call_site(),
@@ -86,7 +86,7 @@ impl Parse for CodeBlockFs {
             std::env::var("CARGO_MANIFEST_DIR")
                 .map_err(|_| syn::Error::new(Span::call_site(), "CARGO_MANIFEST_DIR not found"))?,
         );
-        let path = path.join(&code_path);
+        let path = path.join(code_path);
         let code = std::fs::read_to_string(&path).map_err(|err| {
             syn::Error::new(
                 Span::call_site(),
@@ -102,10 +102,10 @@ impl Parse for CodeBlockFs {
         let html = syntect::html::highlighted_html_for_string(
             &code,
             &syntect::parsing::SyntaxSet::load_defaults_newlines(),
-            &syntect::parsing::SyntaxSet::load_defaults_newlines()
+            syntect::parsing::SyntaxSet::load_defaults_newlines()
                 .find_syntax_by_extension(extension)
                 .unwrap(),
-            &syntect::highlighting::ThemeSet::load_defaults()
+            syntect::highlighting::ThemeSet::load_defaults()
                 .themes
                 .get(&theme)
                 .unwrap(),


### PR DESCRIPTION
This PR inserts spaces after newlines which fixes some words being pushed together without a space in the docsite

Fixes https://github.com/DioxusLabs/include_mdbook/issues/3
Fixes https://github.com/DioxusLabs/docsite/issues/243